### PR TITLE
fix: project.dependencies is not a valid member or project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -398,8 +398,8 @@ class JuliaDocServer {
             project = Pkg.Types.read_project(joinpath("${path}", "Project.toml"))
             println("Project: ", project.name, " v", project.version)
             println("\\nDependencies:")
-            for (dep, ver) in project.dependencies
-              println(" - ", dep, " = ", ver)
+            for (dep, uuid) in project.deps
+              println(" - ", dep, " = ", uuid)
             end
           `;
           


### PR DESCRIPTION
Updated the tool `explore-project` Julia command to iterate over `project.deps` instead of `project.dependencies`